### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ JIVAS action wrapper around the LangChain library for abstracted LLM interfacing
 - **Name:** `jivas/langchain_model_action`
 - **Author:** [V75 Inc.](https://v75inc.com/)
 - **Architype:** `LangChainModelAction`
-- **Version:** `0.0.1`
 
 ## Meta Information
 


### PR DESCRIPTION
This pull request includes a small change to the `README.md` file. The change removes the version information for the `LangChainModelAction` archetype. 

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L16): Removed the version information for the `LangChainModelAction` archetype.