### PR TITLE
Remove redundant version

### DIFF
--- a/langchain_model_action/README.md
+++ b/langchain_model_action/README.md
@@ -13,7 +13,6 @@ JIVAS action wrapper around the LangChain library for abstracted LLM interfacing
 - **Name:** `jivas/langchain_model_action`
 - **Author:** [V75 Inc.](https://v75inc.com/)
 - **Architype:** `LangChainModelAction`
-- **Version:** `0.0.1`
 
 ## Meta Information
 


### PR DESCRIPTION
This pull request includes a minor change to the `langchain_model_action/README.md` file. The change removes the version information from the meta information section.

* [`langchain_model_action/README.md`](diffhunk://#diff-d60c15f1035597d74e8d98aab16da6ab48d5bd1e163e1fbfd50d1fd9273e0216L16): Removed the version information from the meta information section.