### PR TITLE
Relax langchain action pip deps

### DIFF
--- a/langchain_model_action/CHANGELOG.md
+++ b/langchain_model_action/CHANGELOG.md
@@ -3,3 +3,6 @@
 
 ## 0.0.2
 - Updated openai dependency to 1.68.2
+
+## 0.0.3
+- Relax version constraints and bump patch version for langchain_model_action.

--- a/langchain_model_action/README.md
+++ b/langchain_model_action/README.md
@@ -13,7 +13,6 @@ JIVAS action wrapper around the LangChain library for abstracted LLM interfacing
 - **Name:** `jivas/langchain_model_action`
 - **Author:** [V75 Inc.](https://v75inc.com/)
 - **Architype:** `LangChainModelAction`
-- **Version:** `0.0.2`
 
 ## Meta Information
 

--- a/langchain_model_action/info.yaml
+++ b/langchain_model_action/info.yaml
@@ -2,7 +2,7 @@ package:
   name: jivas/langchain_model_action
   author: V75 Inc.
   architype: LangChainModelAction
-  version: 0.0.2
+  version: 0.0.3
   meta:
     title: LangChain Model Action
     description: JIVAS action wrapper around LangChain library for abstracted LLM interfacing.
@@ -13,12 +13,12 @@ package:
   dependencies:
     jivas: ^2.0.0
     pip:
-      openai: 1.68.2
-      langchain: 0.3.21
-      langchain-community: 0.3.20
-      langchain-core: 0.3.47
-      langchain-experimental: 0.3.4
-      langchain-openai: 0.3.9
+      openai: ">=1.68.2"
+      langchain: ">=0.3.21"
+      langchain-community: ">=0.3.20"
+      langchain-core: ">=0.3.47"
+      langchain-experimental: ">=0.3.4"
+      langchain-openai: ">=0.3.9"
 
 
 


### PR DESCRIPTION
## Type of Change
- [ ] 🐛 Bug Fix
- [ ] 🚀 Feature
- [x] 🔄 Refactor
- [ ] 📖 Documentation
- [ ] 🔧 Other

## Summary
Relax version constraints and bump patch version for `langchain_model_action`.

## Details

### 🔢 Versioning
- Updated version: `0.0.2` → `0.0.3`

### 📦 Dependencies
- Relaxed version pinning for the following dependencies:
  - `openai`
  - `langchain`
  - `langchain-community`
  - `langchain-core`
  - `langchain-experimental`
  - `langchain-openai`
- Switched from exact versioning to minimum version requirements (`>=`) to support greater flexibility and reduce upgrade friction.
