### PR TITLE
Fix interaction_node None type error in model action

### DIFF
--- a/langchain_model_action/CHANGELOG.md
+++ b/langchain_model_action/CHANGELOG.md
@@ -23,3 +23,6 @@
 
 ## 0.1.0
 - Updated to support Jivas 2.1.0
+
+## 0.1.1
+- Fix interaction_node, None type error

--- a/langchain_model_action/info.yaml
+++ b/langchain_model_action/info.yaml
@@ -2,7 +2,7 @@ package:
   name: jivas/langchain_model_action
   author: V75 Inc.
   archetype: LangChainModelAction
-  version: 0.1.0
+  version: 0.1.1
   meta:
     title: LangChain Model Action
     description: JIVAS action wrapper around LangChain library for abstracted LLM interfacing.

--- a/langchain_model_action/langchain_model_action.jac
+++ b/langchain_model_action/langchain_model_action.jac
@@ -31,7 +31,11 @@ node LangChainModelAction(ModelAction) {
         **kwargs:dict
     ) -> Optional[ModelActionResult] {
         interaction_node = kwargs.get("interaction_node");
-        frame_node = interaction_node.get_frame();
+        session_id = "unknown";
+        if interaction_node {
+            frame_node = interaction_node.get_frame();
+            session_id = frame_node.session_id;
+        }
 
         llm = None;
 
@@ -134,7 +138,7 @@ node LangChainModelAction(ModelAction) {
                             event_msg = {
                                	 			"id": interaction_node.id,
                             				"content": chunk.content,
-                                			"session_id": frame_node.session_id,
+                                			"session_id": session_id,
                                             "type": chunk.type,
                                             "metadata": chunk.response_metadata,
                                         };


### PR DESCRIPTION
## **Type of Change**
What type of change does this PR introduce? Mark all that apply:
- [x] 🐛 Bug Fix
- [ ] 🚀 Feature Request
- [ ] 🔄 Refactor
- [ ] 📖 Documentation Update
- [ ] 🔧 Other (Please specify):

---

## **Summary**
### **What does this PR address?**
- Fixes a `NoneType` error in `interaction_node` when attempting to retrieve a session.

---

## **Description**
### **Bug Fixes**:
- **Bug**: The `interaction_node` was throwing a `NoneType` error when trying to access a session that did not exist.
- **Root Cause**: The code assumed the session would always be available, but did not handle cases where it was `None`.
- **Resolution**: Added a check to ensure the session exists before attempting to access it, preventing the `NoneType` error.

---

## **Changes Made**
### High-Level Summary:
1. Added a conditional check in `interaction_node` to verify session existence before access.
2. Improved error handling for cases where the session is `None`.

---

## **Checklist**
Mark all that apply:
- [x] Code follows the project’s coding guidelines.
- [ ] Tests have been added or updated for new functionality.
- [ ] Documentation has been updated (if applicable).
- [x] Existing tests pass locally with these changes.
- [ ] Any dependencies introduced are justified and documented.

---

## **Steps to Test**
1. Trigger an interaction where the session might be `None`.
2. Verify that no `NoneType` error occurs and the interaction handles the missing session gracefully.

---

## **Additional Context**
N/A

---

## **Questions or Concerns**
- Are there additional edge cases where the session might be unexpectedly `None` that should be handled?